### PR TITLE
Fix Cookies From Browser being ignored when fetching Info only

### DIFF
--- a/src/NYoutubeDL/Services/InfoService.cs
+++ b/src/NYoutubeDL/Services/InfoService.cs
@@ -270,6 +270,10 @@ namespace NYoutubeDL.Services
                 {
                     NoPlaylist = ydl.Options.VideoSelectionOptions.NoPlaylist,
                     YoutubeMediaConnectClient = ydl.Options.VideoSelectionOptions.YoutubeMediaConnectClient
+                },
+                WorkaroundsOptions =
+                {
+                    CookiesFromBrowser = ydl.Options.WorkaroundsOptions.CookiesFromBrowser
                 }
             };
 


### PR DESCRIPTION
When fetching info only with yt-dlp, the cookies from browser option would get lost. This fixes that.