### PR TITLE
tweak: Add YouTube web_safari client by default

### DIFF
--- a/src/NYoutubeDL/Options/VideoSelection.cs
+++ b/src/NYoutubeDL/Options/VideoSelection.cs
@@ -72,6 +72,8 @@ namespace NYoutubeDL.Options
 
         [Option] internal readonly BoolOption youtubeMediaConnect = new BoolOption("--extractor-args \"youtube:player_client=mediaconnect\"");
 
+        [Option] internal readonly BoolOption youtubeWebSafari = new BoolOption("--extractor-args \"youtube:player_client=default,web_safari\"");
+
         /// <summary>
         ///     --age-limit
         /// </summary>
@@ -251,6 +253,18 @@ namespace NYoutubeDL.Options
         {
             get => this.youtubeMediaConnect.Value ?? false;
             set => this.SetField(ref this.youtubeMediaConnect.Value, value);
+        }
+
+        /// <summary>
+        ///     --extractor-args "youtube:player_client=default,web_safari"
+        /// </summary>
+        public bool YoutubeWebSafariClient
+        {
+            // Enable by default to offer 1080p merged video+audio formats
+            // for users with cookies linked to a YouTube Premium account
+            // https://github.com/yt-dlp/yt-dlp/issues/14575
+            get => this.youtubeWebSafari.Value ?? true;
+            set => this.SetField(ref this.youtubeWebSafari.Value, value);
         }
     }
 }

--- a/src/NYoutubeDL/Services/InfoService.cs
+++ b/src/NYoutubeDL/Services/InfoService.cs
@@ -271,7 +271,8 @@ namespace NYoutubeDL.Services
                 VideoSelectionOptions =
                 {
                     NoPlaylist = ydl.Options.VideoSelectionOptions.NoPlaylist,
-                    YoutubeMediaConnectClient = ydl.Options.VideoSelectionOptions.YoutubeMediaConnectClient
+                    YoutubeMediaConnectClient = ydl.Options.VideoSelectionOptions.YoutubeMediaConnectClient,
+                    YoutubeWebSafariClient = ydl.Options.VideoSelectionOptions.YoutubeWebSafariClient,
                 },
                 WorkaroundsOptions =
                 {


### PR DESCRIPTION
The web_safari client gives access to pre-merged audio+video formats with high resolutions. It is already used by default in most cases, [except for users with cookies linked to a YouTube Premium account](https://github.com/yt-dlp/yt-dlp/issues/14575), which paradoxically causes users with Premium to be stuck with 360p videos in Resonite.

This change adds this option by default on all requests, which will have no impact for most users, but will allow users with YouTube Premium accounts to access high resolution videos like all other users, at the tiny overhead cost of a few additional requests to fetch the available formats for this additional client.

I compiled and tested this locally with my install of Resonite, and I can confirm that this works, both with and without the cookies option being enabled.

This should not cause any breakage in the future even if one day yt-dlp removes the web_safari client, because yt-dlp simply ignores unknown client arguments and carries on with the defaults:
```
λ ~/Dev/ yt-dlp -F --extractor-args "youtube:player_client=default,tatata" "https://www.youtube.com/watch?v=5_dZXZ0GRoA"
<... Some info messages ...>
WARNING: [youtube] Skipping unsupported client "tatata"
<... Displays the table of available formats ...>
```