### PR TITLE
Add method to explicitly update yt-dlp without running any download

### DIFF
--- a/src/NYoutubeDL/YoutubeDL.cs
+++ b/src/NYoutubeDL/YoutubeDL.cs
@@ -191,6 +191,13 @@ namespace NYoutubeDL
             this.semaphore.Release();
         }
 
+        public async Task Update(string updateChannel)
+        {
+            await this.semaphore.WaitAsync();
+            await PreparationService.Update(this, updateChannel, CancellationToken.None);
+            this.semaphore.Release();
+        }
+
         /// <summary>
         ///     Get information about the video/playlist before downloading
         /// </summary>


### PR DESCRIPTION
This is to allow explicit updates without being tied to a download