### PR TITLE
fix: Use ytdl's directory as working directory

### DIFF
--- a/src/NYoutubeDL/Services/PreparationService.cs
+++ b/src/NYoutubeDL/Services/PreparationService.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright 2018 Brian Allred
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal in the Software without restriction, including without limitation the
 // rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 // sell copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -198,13 +198,14 @@ namespace NYoutubeDL.Services
                 uri = new Uri(ydl.VideoUrl);
 
             string arguments = ydl.Options.ToCliParameters();
-            
+
             if(uri != null)
                 arguments += " " + uri.AbsoluteUri;
 
             ydl.processStartInfo = new ProcessStartInfo
             {
                 FileName = ydl.YoutubeDlPath,
+                WorkingDirectory = Path.GetDirectoryName(ydl.YoutubeDlPath) ?? "",
                 Arguments = arguments,
                 CreateNoWindow = true,
                 RedirectStandardError = true,


### PR DESCRIPTION
Specifies the directory of the ytdl executable as the working directory for the process.

Should fix Yellow-Dog-Man/Resonite-Issues#6263.